### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/_widgets/social.html
+++ b/layouts/partials/_widgets/social.html
@@ -12,7 +12,7 @@
                                 {{ with .Site.Params.Social.linkedin }}<a href="http://no.linkedin.com/in/{{ . }}/en" title="Linkedin" target="_blank"> <i class='icon icon-linkedin-square'></i></a>{{ end }}
                                 {{ with .Site.Params.Social.skype }}<a href="skype:{{ . }}?call" title="Call {{ . }} on skype"> <i class='icon icon-skype'></i></a>{{ end }}
                                 {{ with .Site.Params.Social.email }}<a href="mailto:{{ . }}" title="Email {{ . }}"> <i class='icon icon-envelope-o'></i></a>{{ end }}
-                                {{ if .RSSlink }}<a href="{{ .RSSlink }}" /> <i class='icon icon-rss'></i></a>{{ end }}
+                                {{ if .RSSLink }}<a href="{{ .RSSLink }}" /> <i class='icon icon-rss'></i></a>{{ end }}
                                 {{ with .Site.Params.Social.dribble }}<a href="{{ . }}" target="_blank"> <i class="icon icon-dribbble"></i></a>{{ end }}
                                 {{ with .Site.Params.Social.vimeo }}<a href="{{ . }}" target="_blank"> <i class="icon icon-vimeo"></i></a>{{ end }}
                                 {{ with .Site.Params.Social.pinterest }}<a href="{{ . }}" target="_blank"> <i class="icon icon-pinterest"></i></a>{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,8 +5,8 @@
 {{ partial "header.includes.html" . }}
     {{ `<!--[if lt IE 9]><script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script><script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script><![endif]-->` | safeHTML }}
     <!-- RSS -->
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
 </head>

--- a/layouts/partials/profile_heading.html
+++ b/layouts/partials/profile_heading.html
@@ -17,7 +17,7 @@
                   {{ with .Site.Params.Social.linkedin }}<a href="http://no.linkedin.com/in/{{ . }}/en" title="Linkedin" target="_blank"> <i class='icon icon-linkedin-square'></i></a>{{ end }}
                   {{ with .Site.Params.Social.skype }}<a href="skype:{{ . }}?call" title="Call {{ . }} on skype"> <i class='icon icon-skype'></i></a>{{ end }}
                   {{ with .Site.Params.Social.email }}<a href="mailto:{{ . }}" title="Email {{ . }}"> <i class='icon icon-envelope-o'></i></a>{{ end }}
-                  {{ if .RSSlink }}<a href="{{ .RSSlink }}" /> <i class='icon icon-rss'></i></a>{{ end }}
+                  {{ if .RSSLink }}<a href="{{ .RSSLink }}" /> <i class='icon icon-rss'></i></a>{{ end }}
               </div>
               {{ end }}
             </div>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.